### PR TITLE
fix: Resolve symlink issue with packaged Mac library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ library:
 		mkdir -p output; \
 		rm -rf output/C2PAC.xcframework output/C2PAC.xcframework.zip; \
 		cp -R Library/Frameworks/C2PAC.xcframework output/; \
-		cd output && zip -r C2PAC.xcframework.zip C2PAC.xcframework > /dev/null; \
+		cd output && zip -ry C2PAC.xcframework.zip C2PAC.xcframework > /dev/null; \
 		echo "XCFramework packaged to output/C2PAC.xcframework.zip"; \
 	else \
 		echo "::error::Failed to find frameworks for all platforms"; \


### PR DESCRIPTION
## Changes in this pull request
Symlinks were being stored incorrectly when the framework was .zipped in CI. Updating the flags to the zip command resolves the issue.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment