### PR TITLE
fix: Add keychain entitlement to TestApp MacCatalyst target

### DIFF
--- a/TestApp/Sources/TestApp.entitlements
+++ b/TestApp/Sources/TestApp.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)org.contentauth.TestApp</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
## Changes in this pull request
Adds a keychain entitlement to TestApp which allows the Secure Enclave tests to pass

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment