### PR TITLE
feat: FFI migration and Builder/Reader updates

### DIFF
--- a/ExampleApp/Sources/C2PAManager.swift
+++ b/ExampleApp/Sources/C2PAManager.swift
@@ -121,7 +121,7 @@ final class C2PAManager: ObservableObject {
                 os_log("Starting C2PA verification of saved file...", log: Logger.verification, type: .info)
                 do {
                     // Read the file back and verify C2PA credentials
-                    let manifestJSON = try C2PA.readFile(at: savedURL, dataDir: nil)
+                    let manifestJSON = try C2PA.readFile(at: savedURL)
 
                     os_log("C2PA VERIFICATION SUCCESS", log: Logger.verification, type: .info)
                     os_log("Manifest JSON loaded successfully", log: Logger.verification, type: .info)

--- a/Library/Sources/Builder.swift
+++ b/Library/Sources/Builder.swift
@@ -35,10 +35,16 @@ import Foundation
 /// - ``addAction(_:)``
 /// - ``setNoEmbed()``
 /// - ``setRemote(url:)``
+/// - ``setBasePath(_:)``
+///
+/// ### Introspection
+/// - ``supportedMimeTypes``
 ///
 /// ### Adding Content
 /// - ``addResource(uri:stream:)``
 /// - ``addIngredient(json:format:from:)``
+/// - ``addIngredient(fromArchive:)``
+/// - ``writeIngredientArchive(id:to:)``
 ///
 /// ### Signing and Output
 /// - ``sign(format:source:destination:signer:)``
@@ -83,14 +89,20 @@ import Foundation
 public final class Builder {
     private let ptr: UnsafeMutablePointer<C2paBuilder>
 
+    // The native builder keeps a clone of the context alive, so the Swift wrapper
+    // must live at least as long or state it owns for the native layer dangles.
+    private let context: C2PAContext?
+
     /// Internal initializer that skips validation.
     private init(validatedJSON: String) throws {
         ptr = try guardNotNull(c2pa_builder_from_json(validatedJSON))
+        context = nil
     }
 
     /// Internal initializer that adopts an already-configured native builder.
-    private init(adopting ptr: UnsafeMutablePointer<C2paBuilder>) {
+    private init(adopting ptr: UnsafeMutablePointer<C2paBuilder>, context: C2PAContext?) {
         self.ptr = ptr
+        self.context = context
     }
 
     /// Validates a ``ManifestValidationResult``, logging warnings and throwing on errors.
@@ -136,6 +148,7 @@ public final class Builder {
     /// - Throws: ``C2PAError`` if the archive is invalid or cannot be read.
     public init(archiveStream: Stream) throws {
         ptr = try guardNotNull(c2pa_builder_from_archive(archiveStream.rawPtr))
+        context = nil
     }
 
     /// Creates a new builder from a ``C2PAContext`` and a manifest JSON definition.
@@ -154,7 +167,7 @@ public final class Builder {
     public convenience init(context: C2PAContext, manifestJSON: String) throws {
         let base = try guardNotNull(c2pa_builder_from_context(context.ptr))
         let configured = try guardNotNull(c2pa_builder_with_definition(base, manifestJSON))
-        self.init(adopting: configured)
+        self.init(adopting: configured, context: context)
     }
 
     /// Creates a new builder from a ``C2PAContext`` and a ``ManifestDefinition``.
@@ -175,7 +188,7 @@ public final class Builder {
         try self.init(context: context, manifestJSON: manifest.toJSON())
     }
 
-    deinit { c2pa_builder_free(ptr) }
+    deinit { _ = c2pa_free(ptr) }
 
     /// Sets the builder intent, specifying what kind of manifest to create.
     ///
@@ -260,6 +273,26 @@ public final class Builder {
         )
     }
 
+    /// Sets the base directory used to resolve relative resource paths in the manifest.
+    ///
+    /// - Parameter url: A directory URL used as the base path for resolving resources.
+    ///
+    /// - Throws: ``C2PAError`` if the base path cannot be set.
+    public func setBasePath(_ url: URL) throws {
+        _ = try guardNonNegative(
+            Int64(c2pa_builder_set_base_path(ptr, url.path))
+        )
+    }
+
+    /// The MIME types supported by the builder for signing.
+    ///
+    /// - Returns: An array of supported MIME type strings (e.g. `"image/jpeg"`).
+    public static var supportedMimeTypes: [String] {
+        var count: UInt = 0
+        let ptr = c2pa_builder_supported_mime_types(&count)
+        return stringArrayFromC(ptr, count: Int(count))
+    }
+
     /// Adds a resource to the manifest.
     ///
     /// Resources are auxiliary files (like thumbnails or metadata) that are
@@ -288,11 +321,37 @@ public final class Builder {
     ///   - stream: A ``Stream`` containing the ingredient file data.
     ///
     /// - Throws: ``C2PAError`` if the ingredient cannot be added.
-    ///
-    /// - SeeAlso: ``C2PA/readIngredient(at:dataDir:)``
     public func addIngredient(json: String, format: String, from stream: Stream) throws {
         _ = try guardNonNegative(
             Int64(c2pa_builder_add_ingredient_from_stream(ptr, json, format, stream.rawPtr))
+        )
+    }
+
+    /// Adds an ingredient previously exported as a C2PA ingredient archive.
+    ///
+    /// - Parameter stream: A ``Stream`` containing a C2PA ingredient archive.
+    ///
+    /// - Throws: ``C2PAError`` if the archive cannot be read or added.
+    ///
+    /// - SeeAlso: ``writeIngredientArchive(id:to:)``
+    public func addIngredient(fromArchive stream: Stream) throws {
+        _ = try guardNonNegative(
+            Int64(c2pa_builder_add_ingredient_from_archive(ptr, stream.rawPtr))
+        )
+    }
+
+    /// Writes a previously added ingredient out as a standalone C2PA ingredient archive.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the ingredient to export.
+    ///   - stream: A ``Stream`` where the ingredient archive will be written.
+    ///
+    /// - Throws: ``C2PAError`` if the ingredient cannot be written.
+    ///
+    /// - SeeAlso: ``addIngredient(fromArchive:)``
+    public func writeIngredientArchive(id: String, to stream: Stream) throws {
+        _ = try guardNonNegative(
+            Int64(c2pa_builder_write_ingredient_archive(ptr, id, stream.rawPtr))
         )
     }
 
@@ -361,10 +420,7 @@ public final class Builder {
                 signer.ptr,
                 &manifestPtr)
         )
-        guard let mp = manifestPtr else { return Data() }
-        let data = Data(bytes: mp, count: Int(size))
-        c2pa_manifest_bytes_free(mp)
-        return data
+        return manifestData(length: size, pointer: manifestPtr)
     }
 
     // MARK: - Embeddable & Data-Hash Signing

--- a/Library/Sources/C2PA.docc/C2PA.md
+++ b/Library/Sources/C2PA.docc/C2PA.md
@@ -12,13 +12,12 @@ The library wraps the Rust-based C2PA implementation via C bindings, providing a
 
 ### Reading Content Credentials
 
-- ``C2PA/readFile(at:dataDir:)``
-- ``C2PA/readIngredient(at:dataDir:)``
+- ``C2PA/readFile(at:)``
 - ``Reader``
 
 ### Creating and Signing Content
 
-- ``C2PA/signFile(source:destination:manifestJSON:signerInfo:dataDir:)``
+- ``C2PA/signFile(source:destination:manifestJSON:signerInfo:)``
 - ``Builder``
 - ``Signer``
 

--- a/Library/Sources/C2PA.swift
+++ b/Library/Sources/C2PA.swift
@@ -22,163 +22,76 @@ import Foundation
 /// ## Topics
 ///
 /// ### Reading Manifests
-/// - ``readFile(at:dataDir:)``
-/// - ``readIngredient(at:dataDir:)``
+/// - ``readFile(at:)``
 ///
 /// ### Signing Files
-/// - ``signFile(source:destination:manifestJSON:signerInfo:dataDir:)``
+/// - ``signFile(source:destination:manifestJSON:signerInfo:)``
 public enum C2PA {
 
     public static var version: String {
         let p = c2pa_version()!
-        defer { c2pa_string_free(p) }
+        defer { _ = c2pa_free(p) }
         return String(cString: p)
     }
 
     /// Reads the C2PA manifest from a file and returns it as JSON.
     ///
-    /// This method extracts and validates the C2PA manifest embedded in a media file,
-    /// returning the manifest data as a JSON string.
+    /// Opens the file as a stream, infers its MIME type from the file extension,
+    /// and returns the embedded manifest as a JSON string.
     ///
-    /// - Parameters:
-    ///   - url: The URL of the file to read the manifest from.
-    ///   - dataDir: Optional directory for storing temporary or cached data during processing.
+    /// - Parameter url: The URL of the file to read the manifest from.
     ///
     /// - Returns: A JSON string containing the C2PA manifest data.
     ///
-    /// - Throws: ``C2PAError`` if the file cannot be read, has no manifest, or contains invalid data.
+    /// - Throws: ``C2PAError`` if the file cannot be read, the type is unknown,
+    ///   or it contains no valid manifest.
     ///
     /// ## Example
     ///
     /// ```swift
-    /// do {
-    ///     let manifestJSON = try C2PA.readFile(at: imageURL)
-    ///     print("Manifest: \(manifestJSON)")
-    /// } catch {
-    ///     print("Failed to read manifest: \(error)")
-    /// }
+    /// let manifestJSON = try C2PA.readFile(at: imageURL)
     /// ```
-    ///
-    /// - SeeAlso: ``readIngredient(at:dataDir:)``
-    public static func readFile(
-        at url: URL,
-        dataDir: URL? = nil
-    ) throws -> String {
-        try stringFromC(
-            c2pa_read_file(url.path, dataDir?.path)
-        )
-    }
-
-    /// Reads ingredient information from a file that will be used in a C2PA manifest.
-    ///
-    /// This method extracts information about a media file that will be referenced as an
-    /// ingredient (source material) in a new C2PA manifest. Ingredients represent the
-    /// original or modified content used to create a new asset.
-    ///
-    /// - Parameters:
-    ///   - url: The URL of the ingredient file to read.
-    ///   - dataDir: Optional directory for storing temporary or cached data during processing.
-    ///
-    /// - Returns: A JSON string containing the ingredient information.
-    ///
-    /// - Throws: ``C2PAError`` if the file cannot be read or processed as an ingredient.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// do {
-    ///     let ingredientJSON = try C2PA.readIngredient(at: originalImageURL)
-    ///     // Use ingredientJSON when building a new manifest
-    /// } catch {
-    ///     print("Failed to read ingredient: \(error)")
-    /// }
-    /// ```
-    ///
-    /// - SeeAlso: ``readFile(at:dataDir:)``
-    public static func readIngredient(
-        at url: URL,
-        dataDir: URL? = nil
-    ) throws -> String {
-        let result = c2pa_read_ingredient_file(url.path, dataDir?.path)
-        guard let result = result else {
-            let errorMsg = lastC2PAError()
-            // TODO: This special case handling may be removable if the underlying C API
-            // is updated to handle NULL data_dir consistently with c2pa_read_file
-            if errorMsg.contains("null parameter data_dir") || errorMsg.contains("data_dir") {
-                throw C2PAError.ingredientDataNotFound(errorMsg)
-            }
-            throw C2PAError.api(errorMsg)
-        }
-        return try stringFromC(result)
+    public static func readFile(at url: URL) throws -> String {
+        let stream = try Stream(readFrom: url)
+        let format = try inferredMIMEType(for: url)
+        let reader = try Reader(format: format, stream: stream)
+        return try reader.json()
     }
 
     /// Signs a media file with a C2PA manifest using PEM-encoded certificates and keys.
     ///
-    /// This convenience method creates a signed copy of the source file with an embedded
-    /// C2PA manifest. The manifest contains assertions about the content, its provenance,
-    /// and is cryptographically signed using the provided credentials.
+    /// Streams the source through a context-based ``Builder`` and writes the signed
+    /// result to `destination`. The media format is inferred from the source extension.
     ///
     /// - Parameters:
     ///   - source: The URL of the source file to sign.
     ///   - destination: The URL where the signed file will be written.
     ///   - manifestJSON: A JSON string defining the C2PA manifest structure and assertions.
     ///   - signerInfo: The signing credentials including certificate chain and private key.
-    ///   - dataDir: Optional directory for storing temporary or cached data during processing.
     ///
-    /// - Throws: ``C2PAError`` if signing fails due to invalid inputs, I/O errors, or cryptographic issues.
+    /// - Throws: ``C2PAError`` if signing fails due to invalid inputs, I/O errors,
+    ///   an unknown file type, or cryptographic issues.
     ///
-    /// ## Example
+    /// - Note: For advanced scenarios (hardware-backed keys, streaming), use
+    ///   ``Builder`` with a ``Signer`` instance directly.
     ///
-    /// ```swift
-    /// let signerInfo = SignerInfo(
-    ///     certificatePEM: certPEM,
-    ///     privateKeyPEM: keyPEM,
-    ///     algorithm: .es256,
-    ///     tsa: URL(string: "http://timestamp.digicert.com")
-    /// )
-    ///
-    /// try C2PA.signFile(
-    ///     source: sourceURL,
-    ///     destination: destURL,
-    ///     manifestJSON: manifestJSON,
-    ///     signerInfo: signerInfo
-    /// )
-    /// ```
-    ///
-    /// - Note: For more advanced signing scenarios, including hardware-backed keys
-    ///   and streaming operations, use ``Builder`` with a ``Signer`` instance.
-    ///
-    /// - SeeAlso: ``Builder``, ``Signer``, ``SignerInfo``
+    /// - SeeAlso: ``Builder``, ``Signer``, ``SignerInfo``, ``C2PAContext``
     public static func signFile(
         source: URL,
         destination: URL,
         manifestJSON: String,
-        signerInfo: SignerInfo,
-        dataDir: URL? = nil
+        signerInfo: SignerInfo
     ) throws {
-        var maybeErr: UnsafeMutablePointer<CChar>?
-        withSignerInfo(
-            algorithm: signerInfo.algorithm.rawValue,
-            cert: signerInfo.certificatePEM,
-            key: signerInfo.privateKeyPEM,
-            tsa: signerInfo.tsa
-        ) { algPtr, certPtr, keyPtr, tsaPtr in
-            var sInfo = C2paSignerInfo(
-                alg: algPtr,
-                sign_cert: certPtr,
-                private_key: keyPtr,
-                ta_url: tsaPtr)
-            maybeErr = c2pa_sign_file(
-                source.path,
-                destination.path,
-                manifestJSON,
-                &sInfo,
-                dataDir?.path)
-        }
-
-        if let e = maybeErr {
-            let msg = try stringFromC(e)
-            throw C2PAError.api(msg)
-        }
+        let format = try inferredMIMEType(for: source)
+        let sourceStream = try Stream(readFrom: source)
+        let destStream = try Stream(writeTo: destination)
+        let signer = try Signer(info: signerInfo)
+        let builder = try Builder(context: C2PAContext(), manifestJSON: manifestJSON)
+        _ = try builder.sign(
+            format: format,
+            source: sourceStream,
+            destination: destStream,
+            signer: signer
+        )
     }
 }

--- a/Library/Sources/C2PAError.swift
+++ b/Library/Sources/C2PAError.swift
@@ -25,7 +25,6 @@ import Foundation
 /// - ``nilPointer``
 /// - ``utf8``
 /// - ``negative(_:)``
-/// - ``ingredientDataNotFound(_:)``
 /// - ``ed25519NotSupported``
 /// - ``keySearchFailed(_:_:_:)``
 /// - ``unsupportedAlgorithm(_:_:)``
@@ -52,11 +51,6 @@ public enum C2PAError: Error, LocalizedError {
     ///
     /// - Parameter value: The negative status value.
     case negative(_ value: Int64)
-
-    /// The underlying C API probably experienced a NULL data_dir.
-    ///
-    /// - Parameter original: Original error message from C API.
-    case ingredientDataNotFound(_ original: String)
 
     /// Ed25519 algorithm is not supported by the Keychain.
     case ed25519NotSupported
@@ -105,9 +99,6 @@ public enum C2PAError: Error, LocalizedError {
 
         case .negative(let value):
             return "C2PA negative status \(value)"
-
-        case .ingredientDataNotFound(let original):
-            return "No ingredient data found: \(original)"
 
         case .ed25519NotSupported:
             return "Ed25519 not supported by Keychain"

--- a/Library/Sources/Helpers.swift
+++ b/Library/Sources/Helpers.swift
@@ -13,11 +13,12 @@
 
 import C2PAC
 import Foundation
+import UniformTypeIdentifiers
 
 @inline(__always)
 func stringFromC(_ p: UnsafeMutablePointer<CChar>?) throws -> String {
     guard let p else { throw C2PAError.api(lastC2PAError()) }
-    defer { c2pa_string_free(p) }
+    defer { _ = c2pa_free(p) }
     guard let s = String(validatingCString: p) else { throw C2PAError.utf8 }
     return s
 }
@@ -25,7 +26,7 @@ func stringFromC(_ p: UnsafeMutablePointer<CChar>?) throws -> String {
 @inline(__always)
 func lastC2PAError() -> String {
     guard let p = c2pa_error() else { return "Unknown C2PA error" }
-    defer { c2pa_string_free(p) }
+    defer { _ = c2pa_free(p) }
     return String(cString: p)
 }
 
@@ -84,6 +85,19 @@ func asStreamCtx(_ p: UnsafeMutableRawPointer) -> UnsafeMutablePointer<StreamCon
     UnsafeMutablePointer<StreamContext>(OpaquePointer(p))
 }
 
+/// Converts a C string array (with its element count) to `[String]`, then frees the
+/// native array with `c2pa_free_string_array`. Returns `[]` for a nil array.
+func stringArrayFromC(_ ptr: UnsafePointer<UnsafePointer<CChar>?>?, count: Int) -> [String] {
+    guard let ptr, count > 0 else { return [] }
+    var result: [String] = []
+    result.reserveCapacity(count)
+    for i in 0..<count {
+        if let cStr = ptr[i] { result.append(String(cString: cStr)) }
+    }
+    c2pa_free_string_array(ptr, UInt(count))
+    return result
+}
+
 /// Builds `Data` from the `(int64 length, out **bytes)` pattern used by the embeddable
 /// FFI calls, freeing the native buffer with `c2pa_free`. `length` is the guarded,
 /// non-negative result; `pointer` is the out-parameter the call populated.
@@ -92,4 +106,16 @@ func manifestData(length: Int64, pointer: UnsafePointer<UInt8>?) -> Data {
     defer { _ = c2pa_free(pointer) }
     guard length > 0 else { return Data() }
     return Data(bytes: pointer, count: Int(length))
+}
+
+/// Infers the MIME type for a file URL from its path extension.
+///
+/// - Parameter url: The file URL whose extension determines the MIME type.
+/// - Returns: The preferred MIME type (e.g. `"image/jpeg"`).
+/// - Throws: ``C2PAError`` if the extension maps to no known type.
+func inferredMIMEType(for url: URL) throws -> String {
+    guard let mime = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType else {
+        throw C2PAError.api("Unsupported or unknown file type for extension '\(url.pathExtension)'")
+    }
+    return mime
 }

--- a/Library/Sources/Reader.swift
+++ b/Library/Sources/Reader.swift
@@ -20,12 +20,14 @@ import Foundation
 /// embedded in media files. Use this class when you need fine-grained control
 /// over reading operations or when working with stream-based I/O.
 ///
-/// For simple file-based reading, consider using ``C2PA/readFile(at:dataDir:)`` instead.
+/// For simple file-based reading, consider using ``C2PA/readFile(at:)`` instead.
 ///
 /// ## Topics
 ///
 /// ### Creating a Reader
+/// - ``init(context:format:stream:)``
 /// - ``init(format:stream:)``
+/// - ``init(context:format:stream:manifest:)``
 /// - ``init(format:stream:manifest:)``
 ///
 /// ### Reading Manifest Data
@@ -37,6 +39,9 @@ import Foundation
 /// ### Extracting Resources
 /// - ``resource(uri:to:)``
 ///
+/// ### Introspection
+/// - ``supportedMimeTypes``
+///
 /// ## Example
 ///
 /// ```swift
@@ -46,27 +51,87 @@ import Foundation
 /// print("Manifest: \(manifestJSON)")
 /// ```
 ///
-/// - SeeAlso: ``Stream``, ``C2PA/readFile(at:dataDir:)``
+/// - SeeAlso: ``Stream``, ``C2PA/readFile(at:)``
 public final class Reader {
     private let ptr: UnsafeMutablePointer<C2paReader>
 
+    // The native reader keeps a clone of the context alive, so the Swift wrapper
+    // must live at least as long or state it owns for the native layer dangles.
+    private let context: C2PAContext?
+
+    /// Adopts an already-built native reader.
+    private init(adopting reader: UnsafeMutablePointer<C2paReader>, context: C2PAContext?) {
+        self.ptr = reader
+        self.context = context
+    }
+
+    /// Creates a reader for a media file stream using a configured context.
+    ///
+    /// The reader inherits the context's configuration (settings such as verify
+    /// and trust options, and any HTTP resolver), so they apply while reading.
+    ///
+    /// - Parameters:
+    ///   - context: The ``C2PAContext`` providing shared configuration.
+    ///   - format: The MIME type of the media file (e.g., "image/jpeg", "video/mp4").
+    ///   - stream: A ``Stream`` containing the media file data.
+    ///
+    /// - Throws: ``C2PAError`` if the stream cannot be read or contains no valid manifest.
+    ///
+    /// - SeeAlso: ``C2PAContext``
+    public convenience init(context: C2PAContext, format: String, stream: Stream) throws {
+        let base = try guardNotNull(c2pa_reader_from_context(context.ptr))
+        self.init(
+            adopting: try guardNotNull(c2pa_reader_with_stream(base, format, stream.rawPtr)),
+            context: context
+        )
+    }
+
     /// Creates a reader for a media file stream.
     ///
-    /// This initializer reads the manifest embedded in the media file itself.
+    /// This initializer reads the manifest embedded in the media file itself,
+    /// using a default context.
     ///
     /// - Parameters:
     ///   - format: The MIME type of the media file (e.g., "image/jpeg", "video/mp4").
     ///   - stream: A ``Stream`` containing the media file data.
     ///
     /// - Throws: ``C2PAError`` if the stream cannot be read or contains no valid manifest.
-    public init(format: String, stream: Stream) throws {
-        ptr = try guardNotNull(c2pa_reader_from_stream(format, stream.rawPtr))
+    public convenience init(format: String, stream: Stream) throws {
+        try self.init(context: C2PAContext(), format: format, stream: stream)
+    }
+
+    /// Creates a reader from separate manifest data and media stream using a configured context.
+    ///
+    /// - Parameters:
+    ///   - context: The ``C2PAContext`` providing shared configuration.
+    ///   - format: The MIME type of the media file.
+    ///   - stream: A ``Stream`` containing the media file data.
+    ///   - manifest: The raw manifest bytes.
+    ///
+    /// - Throws: ``C2PAError`` if the manifest or stream cannot be processed.
+    ///
+    /// - SeeAlso: ``C2PAContext``
+    public convenience init(context: C2PAContext, format: String, stream: Stream, manifest: Data) throws {
+        let base = try guardNotNull(c2pa_reader_from_context(context.ptr))
+        let reader = try manifest.withUnsafeBytes { buf in
+            try guardNotNull(
+                c2pa_reader_with_manifest_data_and_stream(
+                    base,
+                    format,
+                    stream.rawPtr,
+                    buf.bindMemory(to: UInt8.self).baseAddress,
+                    UInt(manifest.count)
+                )
+            )
+        }
+        self.init(adopting: reader, context: context)
     }
 
     /// Creates a reader from separate manifest data and media stream.
     ///
     /// This initializer is used when the manifest is stored separately from the
     /// media file (e.g., when using remote manifests with ``Builder/setNoEmbed()``).
+    /// It uses a default context.
     ///
     /// - Parameters:
     ///   - format: The MIME type of the media file.
@@ -74,20 +139,11 @@ public final class Reader {
     ///   - manifest: The raw manifest bytes.
     ///
     /// - Throws: ``C2PAError`` if the manifest or stream cannot be processed.
-    public init(format: String, stream: Stream, manifest: Data) throws {
-        ptr = try manifest.withUnsafeBytes { buf in
-            try guardNotNull(
-                c2pa_reader_from_manifest_data_and_stream(
-                    format,
-                    stream.rawPtr,
-                    buf.bindMemory(to: UInt8.self).baseAddress!,
-                    UInt(manifest.count)
-                )
-            )
-        }
+    public convenience init(format: String, stream: Stream, manifest: Data) throws {
+        try self.init(context: C2PAContext(), format: format, stream: stream, manifest: manifest)
     }
 
-    deinit { c2pa_reader_free(ptr) }
+    deinit { _ = c2pa_free(ptr) }
 
     /// Returns the manifest data as a JSON string.
     ///
@@ -157,7 +213,7 @@ public final class Reader {
         guard let cString = c2pa_reader_remote_url(ptr) else {
             return nil
         }
-        defer { c2pa_string_free(UnsafeMutablePointer(mutating: cString)) }
+        defer { _ = c2pa_free(cString) }
         return URL(string: String(cString: cString))
     }
 
@@ -199,5 +255,14 @@ public final class Reader {
         _ = try guardNonNegative(
             c2pa_reader_resource_to_stream(ptr, uri, dest.rawPtr)
         )
+    }
+
+    /// The MIME types supported by the reader for reading manifests.
+    ///
+    /// - Returns: An array of supported MIME type strings (e.g. `"image/jpeg"`).
+    public static var supportedMimeTypes: [String] {
+        var count: UInt = 0
+        let ptr = c2pa_reader_supported_mime_types(&count)
+        return stringArrayFromC(ptr, count: Int(count))
     }
 }

--- a/Library/Sources/Signer.swift
+++ b/Library/Sources/Signer.swift
@@ -365,7 +365,7 @@ public final class Signer {
     }
 
     deinit {
-        c2pa_signer_free(ptr)
+        _ = c2pa_free(ptr)
         retainedContext?.release()
     }
 

--- a/Library/Tests/LibraryTestRunner.swift
+++ b/Library/Tests/LibraryTestRunner.swift
@@ -129,6 +129,21 @@ final class BuilderTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
+    func testBuilderSetBasePath() throws {
+        let result = tests.testBuilderSetBasePath()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testBuilderSupportedMimeTypes() throws {
+        let result = tests.testBuilderSupportedMimeTypes()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testIngredientArchiveRoundtrip() throws {
+        let result = tests.testIngredientArchiveRoundtrip()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
     func testNeedsPlaceholder() throws {
         let result = tests.testNeedsPlaceholder()
         XCTAssertTrue(result.passed, result.message)
@@ -136,6 +151,21 @@ final class BuilderTests: XCTestCase {
 
     func testDataHashSigningWorkflow() throws {
         let result = tests.testDataHashSigningWorkflow()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testBuilderContextManifestDefinition() throws {
+        let result = tests.testBuilderContextManifestDefinition()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testBuilderAddAction() throws {
+        let result = tests.testBuilderAddAction()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testAddIngredientFromArchive() throws {
+        let result = tests.testAddIngredientFromArchive()
         XCTAssertTrue(result.passed, result.message)
     }
 
@@ -151,6 +181,11 @@ final class BuilderTests: XCTestCase {
 
     func testSignDataHashedEmbeddable() throws {
         let result = tests.testSignDataHashedEmbeddable()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testBuilderFromArchiveRoundtrip() throws {
+        let result = tests.testBuilderFromArchiveRoundtrip()
         XCTAssertTrue(result.passed, result.message)
     }
 
@@ -227,6 +262,16 @@ final class ReaderTests: XCTestCase {
 
     func testReaderDetailedJSONComparison() throws {
         let result = tests.testReaderDetailedJSONComparison()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testReaderSupportedMimeTypes() throws {
+        let result = tests.testReaderSupportedMimeTypes()
+        XCTAssertTrue(result.passed, result.message)
+    }
+
+    func testReaderFromContext() throws {
+        let result = tests.testReaderFromContext()
         XCTAssertTrue(result.passed, result.message)
     }
 }
@@ -373,18 +418,8 @@ final class ComprehensiveTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
-    func testReadIngredient() throws {
-        let result = tests.testReadIngredient()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
     func testInvalidFileHandling() throws {
         let result = tests.testInvalidFileHandling()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testFileOperationsWithDataDir() throws {
-        let result = tests.testFileOperationsWithDataDir()
         XCTAssertTrue(result.passed, result.message)
     }
 
@@ -705,11 +740,6 @@ final class ConvenienceTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
-    func testReadFileWithDataDir() throws {
-        let result = tests.testReadFileWithDataDir()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
     func testReadFileWithoutManifest() throws {
         let result = tests.testReadFileWithoutManifest()
         XCTAssertTrue(result.passed, result.message)
@@ -720,28 +750,13 @@ final class ConvenienceTests: XCTestCase {
         XCTAssertTrue(result.passed, result.message)
     }
 
-    func testReadIngredientWithManifest() throws {
-        let result = tests.testReadIngredientWithManifest()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testReadIngredientWithoutManifest() throws {
-        let result = tests.testReadIngredientWithoutManifest()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testReadIngredientWithoutDataDir() throws {
-        let result = tests.testReadIngredientWithoutDataDir()
+    func testReadFileUnknownExtension() throws {
+        let result = tests.testReadFileUnknownExtension()
         XCTAssertTrue(result.passed, result.message)
     }
 
     func testSignFile() throws {
         let result = tests.testSignFile()
-        XCTAssertTrue(result.passed, result.message)
-    }
-
-    func testSignFileWithDataDir() throws {
-        let result = tests.testSignFileWithDataDir()
         XCTAssertTrue(result.passed, result.message)
     }
 

--- a/TestShared/Sources/BuilderTests.swift
+++ b/TestShared/Sources/BuilderTests.swift
@@ -446,6 +446,69 @@ public final class BuilderTests: TestImplementation {
         }
     }
 
+    public func testBuilderSetBasePath() -> TestResult {
+        do {
+            let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("c2pa_base_\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: dir) }
+            try builder.setBasePath(dir)
+            return .success("Builder Set Base Path", "[PASS] setBasePath accepted a directory")
+        } catch {
+            return .failure("Builder Set Base Path", "Error: \(error)")
+        }
+    }
+
+    public func testBuilderSupportedMimeTypes() -> TestResult {
+        let types = Builder.supportedMimeTypes
+        guard !types.isEmpty else {
+            return .failure("Builder Supported MIME Types", "Expected a non-empty list")
+        }
+        guard types.contains("image/jpeg") else {
+            return .failure("Builder Supported MIME Types", "Expected image/jpeg in \(types.prefix(10))")
+        }
+        return .success("Builder Supported MIME Types", "[PASS] \(types.count) types incl. image/jpeg")
+    }
+
+    public func testIngredientArchiveRoundtrip() -> TestResult {
+        let tempDir = FileManager.default.temporaryDirectory
+        let archiveURL = tempDir.appendingPathComponent("ingredient_\(UUID().uuidString).c2pa")
+        let ingredientURL = tempDir.appendingPathComponent("ing_src_\(UUID().uuidString).jpg")
+        defer {
+            try? FileManager.default.removeItem(at: archiveURL)
+            try? FileManager.default.removeItem(at: ingredientURL)
+        }
+        do {
+            guard let imageData = TestUtilities.loadPexelsTestImage() else {
+                return .failure("Ingredient Archive Roundtrip", "Could not load test image")
+            }
+            try imageData.write(to: ingredientURL)
+
+            let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            let ingredientJSON = "{\"title\": \"archive_ingredient.jpg\", \"relationship\": \"componentOf\"}"
+            let ingredientStream = try Stream(readFrom: ingredientURL)
+            try builder.addIngredient(json: ingredientJSON, format: "image/jpeg", from: ingredientStream)
+
+            let archiveOut = try Stream(writeTo: archiveURL)
+            try builder.writeIngredientArchive(id: "archive_ingredient.jpg", to: archiveOut)
+
+            guard FileManager.default.fileExists(atPath: archiveURL.path),
+                  (try? Data(contentsOf: archiveURL))?.isEmpty == false else {
+                return .failure("Ingredient Archive Roundtrip", "Archive was not written")
+            }
+
+            let importer = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            let archiveIn = try Stream(readFrom: archiveURL)
+            try importer.addIngredient(fromArchive: archiveIn)
+            return .success("Ingredient Archive Roundtrip", "[PASS] wrote and re-imported ingredient archive")
+        } catch let error as C2PAError {
+            return .success("Ingredient Archive Roundtrip", "[WARN] archive API callable (error: \(error))")
+        } catch {
+            return .failure("Ingredient Archive Roundtrip", "Error: \(error)")
+        }
+    }
+
     private func jsonQuoted(_ s: String) -> String {
         let arr = (try? JSONSerialization.data(withJSONObject: [s]))
             .flatMap { String(data: $0, encoding: .utf8) } ?? "[\"\"]"
@@ -497,56 +560,60 @@ public final class BuilderTests: TestImplementation {
         }
     }
 
-    public func testBuilderHashType() -> TestResult {
+    public func testBuilderContextManifestDefinition() -> TestResult {
         do {
-            let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
-            let jpeg = try builder.hashType(format: "image/jpeg")
-            let mp4 = try builder.hashType(format: "video/mp4")
-            guard jpeg == .dataHash, mp4 == .bmffHash else {
-                return .failure("Builder Hash Type", "Unexpected: jpeg=\(jpeg), mp4=\(mp4)")
-            }
-            return .success("Builder Hash Type", "[PASS] image/jpeg -> dataHash, video/mp4 -> bmffHash")
+            let context = try C2PAContext()
+            let manifest = ManifestDefinition(claimGeneratorInfo: [], title: "ctx_def.jpg")
+            _ = try Builder(context: context, manifest: manifest)
+            return .success("Builder Context ManifestDefinition", "[PASS] built from context + ManifestDefinition")
+        } catch let error as C2PAError {
+            return .success("Builder Context ManifestDefinition", "[WARN] callable (error: \(error))")
         } catch {
-            return .failure("Builder Hash Type", "Error: \(error)")
+            return .failure("Builder Context ManifestDefinition", "Error: \(error)")
         }
     }
 
-    public func testBmffMerkleHashing() -> TestResult {
+    public func testBuilderAddAction() -> TestResult {
         do {
-            guard let videoData = TestUtilities.loadVideoTestData() else {
-                return .failure("BMFF Merkle Hashing", "Could not load video1.mp4")
-            }
-            let settingsJSON = "{\"version\":1,\"builder\":{\"created_assertion_labels\":[\"c2pa.actions\"]},"
-                + "\"signer\":{\"local\":{\"alg\":\"es256\","
-                + "\"sign_cert\":\(jsonQuoted(TestUtilities.testCertsPEM)),"
-                + "\"private_key\":\(jsonQuoted(TestUtilities.testPrivateKeyPEM))}}}"
-            let context = try C2PAContext(settings: try C2PASettings(json: settingsJSON))
-            let builder = try Builder(context: context, manifestJSON: TestUtilities.createTestManifestJSON())
-
-            // Fragmented BMFF placeholder workflow (mirrors c2pa-rs
-            // test_bmff_embeddable_workflow_with_mdat_hashes): placeholder reserves the
-            // BmffHash Merkle slots, fixed-size Merkle splits the mdat into 1 KB leaves,
-            // a dummy mdat leaf exercises the path (asset won't validate), and
-            // updateHashFromStream hashes the non-mdat bytes from the real asset.
-            _ = try builder.placeholder(format: "video/mp4")
-            try builder.setFixedSizeMerkle(1)
-            try builder.hashMdatBytes(mdatId: 0, data: Data(repeating: 0xAB, count: 4096), largeSize: true)
-
-            let tempURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent("bmff_\(UUID().uuidString).mp4")
-            defer { try? FileManager.default.removeItem(at: tempURL) }
-            try videoData.write(to: tempURL)
-            try builder.updateHashFromStream(format: "video/mp4", stream: try Stream(readFrom: tempURL))
-
-            let embeddable = try builder.signEmbeddable(format: "video/mp4")
-            guard !embeddable.isEmpty else {
-                return .failure("BMFF Merkle Hashing", "Empty embeddable manifest")
-            }
-            return .success("BMFF Merkle Hashing", "[PASS] fragmented BMFF embeddable: \(embeddable.count) bytes")
+            let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            try builder.addAction(Action(action: "c2pa.edited", softwareAgent: "test/1.0"))
+            return .success("Builder Add Action", "[PASS] addAction returned without error")
         } catch let error as C2PAError {
-            return .success("BMFF Merkle Hashing", "[WARN] BMFF Merkle flow callable (error: \(error))")
+            return .success("Builder Add Action", "[WARN] addAction callable (error: \(error))")
         } catch {
-            return .failure("BMFF Merkle Hashing", "Error: \(error)")
+            return .failure("Builder Add Action", "Error: \(error)")
+        }
+    }
+
+    public func testAddIngredientFromArchive() -> TestResult {
+        let tempDir = FileManager.default.temporaryDirectory
+        let archiveURL = tempDir.appendingPathComponent("ingarch_\(UUID().uuidString).c2pa")
+        let srcURL = tempDir.appendingPathComponent("ingsrc_\(UUID().uuidString).jpg")
+        defer {
+            try? FileManager.default.removeItem(at: archiveURL)
+            try? FileManager.default.removeItem(at: srcURL)
+        }
+        do {
+            guard let imageData = TestUtilities.loadPexelsTestImage() else {
+                return .failure("Add Ingredient From Archive", "Could not load test image")
+            }
+            try imageData.write(to: srcURL)
+
+            let exporter = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            try exporter.addIngredient(
+                json: "{\"title\":\"ing.jpg\",\"relationship\":\"componentOf\"}",
+                format: "image/jpeg",
+                from: try Stream(readFrom: srcURL))
+            // try? so the import path below is always exercised, even if export fails.
+            try? exporter.writeIngredientArchive(id: "ing.jpg", to: try Stream(writeTo: archiveURL))
+
+            let importer = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            try importer.addIngredient(fromArchive: try Stream(readFrom: archiveURL))
+            return .success("Add Ingredient From Archive", "[PASS] imported ingredient archive")
+        } catch let error as C2PAError {
+            return .success("Add Ingredient From Archive", "[WARN] archive import callable (error: \(error))")
+        } catch {
+            return .failure("Add Ingredient From Archive", "Error: \(error)")
         }
     }
 
@@ -603,6 +670,79 @@ public final class BuilderTests: TestImplementation {
         }
     }
 
+    public func testBuilderFromArchiveRoundtrip() -> TestResult {
+        let archiveURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "barch_\(UUID().uuidString).c2pa")
+        defer { try? FileManager.default.removeItem(at: archiveURL) }
+        do {
+            let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            builder.setNoEmbed()
+            try builder.writeArchive(to: try Stream(writeTo: archiveURL))
+            guard FileManager.default.fileExists(atPath: archiveURL.path) else {
+                return .failure("Builder From Archive Roundtrip", "Archive not created")
+            }
+            _ = try Builder(archiveStream: try Stream(readFrom: archiveURL))
+            return .success("Builder From Archive Roundtrip", "[PASS] reopened builder from archive")
+        } catch let error as C2PAError {
+            return .success("Builder From Archive Roundtrip", "[WARN] archive-stream init callable (error: \(error))")
+        } catch {
+            return .failure("Builder From Archive Roundtrip", "Error: \(error)")
+        }
+    }
+
+    public func testBuilderHashType() -> TestResult {
+        do {
+            let builder = try Builder(manifestJSON: TestUtilities.createTestManifestJSON())
+            let jpeg = try builder.hashType(format: "image/jpeg")
+            let mp4 = try builder.hashType(format: "video/mp4")
+            guard jpeg == .dataHash, mp4 == .bmffHash else {
+                return .failure("Builder Hash Type", "Unexpected: jpeg=\(jpeg), mp4=\(mp4)")
+            }
+            return .success("Builder Hash Type", "[PASS] image/jpeg -> dataHash, video/mp4 -> bmffHash")
+        } catch {
+            return .failure("Builder Hash Type", "Error: \(error)")
+        }
+    }
+
+    public func testBmffMerkleHashing() -> TestResult {
+        do {
+            guard let videoData = TestUtilities.loadVideoTestData() else {
+                return .failure("BMFF Merkle Hashing", "Could not load video1.mp4")
+            }
+            let settingsJSON = "{\"version\":1,\"builder\":{\"created_assertion_labels\":[\"c2pa.actions\"]},"
+                + "\"signer\":{\"local\":{\"alg\":\"es256\","
+                + "\"sign_cert\":\(jsonQuoted(TestUtilities.testCertsPEM)),"
+                + "\"private_key\":\(jsonQuoted(TestUtilities.testPrivateKeyPEM))}}}"
+            let context = try C2PAContext(settings: try C2PASettings(json: settingsJSON))
+            let builder = try Builder(context: context, manifestJSON: TestUtilities.createTestManifestJSON())
+
+            // Fragmented BMFF placeholder workflow (mirrors c2pa-rs
+            // test_bmff_embeddable_workflow_with_mdat_hashes): placeholder reserves the
+            // BmffHash Merkle slots, fixed-size Merkle splits the mdat into 1 KB leaves,
+            // a dummy mdat leaf exercises the path (asset won't validate), and
+            // updateHashFromStream hashes the non-mdat bytes from the real asset.
+            _ = try builder.placeholder(format: "video/mp4")
+            try builder.setFixedSizeMerkle(1)
+            try builder.hashMdatBytes(mdatId: 0, data: Data(repeating: 0xAB, count: 4096), largeSize: true)
+
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("bmff_\(UUID().uuidString).mp4")
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+            try videoData.write(to: tempURL)
+            try builder.updateHashFromStream(format: "video/mp4", stream: try Stream(readFrom: tempURL))
+
+            let embeddable = try builder.signEmbeddable(format: "video/mp4")
+            guard !embeddable.isEmpty else {
+                return .failure("BMFF Merkle Hashing", "Empty embeddable manifest")
+            }
+            return .success("BMFF Merkle Hashing", "[PASS] fragmented BMFF embeddable: \(embeddable.count) bytes")
+        } catch let error as C2PAError {
+            return .success("BMFF Merkle Hashing", "[WARN] BMFF Merkle flow callable (error: \(error))")
+        } catch {
+            return .failure("BMFF Merkle Hashing", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         return [
             testBuilderAPI(),
@@ -615,11 +755,18 @@ public final class BuilderTests: TestImplementation {
             testBuilderSetIntentEdit(),
             testBuilderSetIntentUpdate(),
             testReadIngredient(),
+            testBuilderSetBasePath(),
+            testBuilderSupportedMimeTypes(),
+            testIngredientArchiveRoundtrip(),
             testNeedsPlaceholder(),
             testDataHashSigningWorkflow(),
+            testBuilderContextManifestDefinition(),
+            testBuilderAddAction(),
+            testAddIngredientFromArchive(),
             testDataHashedPlaceholder(),
             testFormatEmbeddable(),
             testSignDataHashedEmbeddable(),
+            testBuilderFromArchiveRoundtrip(),
             testBuilderHashType(),
             testBmffMerkleHashing()
         ]

--- a/TestShared/Sources/ComprehensiveTests.swift
+++ b/TestShared/Sources/ComprehensiveTests.swift
@@ -28,16 +28,11 @@ public final class ComprehensiveTests: TestImplementation {
         do {
             _ = try C2PA.readFile(at: URL(fileURLWithPath: "/non/existent/file.jpg"))
             return .failure("Error Handling", "Should have thrown an error")
-        } catch let error as C2PAError {
-            if case .api(let message) = error {
-                if message.contains("No such file") || message.contains("does not exist") || message.contains("Failed")
-                {
-                    return .success("Error Handling", "[PASS] Error handling works correctly")
-                }
-            }
-            return .failure("Error Handling", "Unexpected error: \(error)")
         } catch {
-            return .failure("Error Handling", "Unexpected error: \(error)")
+            // Reading a non-existent file must throw. Since readFile now opens a
+            // stream first, the error may be a Foundation file error (surfaced by
+            // the stream) rather than a C2PAError; either is acceptable here.
+            return .success("Error Handling", "[PASS] Error handling works correctly: \(error)")
         }
     }
 
@@ -379,61 +374,6 @@ public final class ComprehensiveTests: TestImplementation {
         }
     }
 
-    public func testReadIngredient() -> TestResult {
-        // Use Adobe test image which HAS a manifest (unlike Pexels which doesn't)
-        // This properly tests ingredient reading on a file with C2PA data
-        let testFile = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "ingredient_\(UUID().uuidString).jpg")
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("Read Ingredient", "Could not load Adobe test image")
-        }
-
-        do {
-            try imageData.write(to: testFile)
-            defer {
-                try? FileManager.default.removeItem(at: testFile)
-            }
-
-            let manifestJSON = try C2PA.readFile(at: testFile)
-
-            // Adobe image SHOULD have manifest
-            guard !manifestJSON.isEmpty else {
-                return .failure("Read Ingredient", "Adobe test image returned empty manifest")
-            }
-
-            let jsonData = Data(manifestJSON.utf8)
-            guard let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
-                return .failure("Read Ingredient", "Failed to parse manifest JSON")
-            }
-
-            guard let manifests = json["manifests"] as? [String: Any] else {
-                return .failure("Read Ingredient", "No manifests field in Adobe test image")
-            }
-
-            // Check if any manifest has ingredients
-            var hasIngredients = false
-            for (_, manifest) in manifests {
-                if let m = manifest as? [String: Any],
-                    let ingredients = m["ingredients"] as? [[String: Any]],
-                    !ingredients.isEmpty
-                {
-                    hasIngredients = true
-                    break
-                }
-            }
-
-            // Adobe test image may or may not have ingredients, but we successfully checked
-            if hasIngredients {
-                return .success("Read Ingredient", "[PASS] Found ingredients in Adobe test image")
-            } else {
-                return .success("Read Ingredient", "[PASS] Adobe test image has manifest but no ingredients")
-            }
-
-        } catch {
-            return .failure("Read Ingredient", "Failed to read Adobe test image: \(error)")
-        }
-    }
-
     public func testInvalidFileHandling() -> TestResult {
         var testSteps: [String] = []
         let tempURL = FileManager.default.temporaryDirectory
@@ -456,62 +396,6 @@ public final class ComprehensiveTests: TestImplementation {
             testSteps.append("Error: \(error)")
 
             return .success("Invalid File Handling", testSteps.joined(separator: "\n"))
-        }
-    }
-
-    public func testFileOperationsWithDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("File Operations with Data Dir", "Could not load test image")
-        }
-
-        let tempImageFile = FileManager.default.temporaryDirectory
-            .appendingPathComponent("test_image_\(UUID().uuidString).jpg")
-        let dataDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("c2pa_data_\(UUID().uuidString)")
-
-        do {
-            // Write test image
-            try imageData.write(to: tempImageFile)
-            defer {
-                try? FileManager.default.removeItem(at: tempImageFile)
-                try? FileManager.default.removeItem(at: dataDir)
-            }
-
-            // Create data directory
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-            testSteps.append("✓ Created data directory")
-
-            // Read file with data directory
-            let manifestJSON = try C2PA.readFile(at: tempImageFile, dataDir: dataDir)
-            if !manifestJSON.isEmpty {
-                testSteps.append("✓ Read manifest with data directory")
-            }
-
-            // Check if data directory has content
-            let contents = try FileManager.default.contentsOfDirectory(
-                at: dataDir,
-                includingPropertiesForKeys: nil)
-            if !contents.isEmpty {
-                testSteps.append("✓ Data directory contains \(contents.count) item(s)")
-            }
-
-            // Try reading ingredient with data directory
-            do {
-                let ingredientJSON = try C2PA.readIngredient(at: tempImageFile, dataDir: dataDir)
-                if !ingredientJSON.isEmpty {
-                    testSteps.append("✓ Found ingredient: \(ingredientJSON.count) bytes")
-                }
-            } catch {
-                testSteps.append("[WARN] No ingredient data (expected)")
-            }
-
-            return .success("File Operations with Data Dir", testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("✗ Failed: \(error)")
-            return .failure("File Operations with Data Dir", testSteps.joined(separator: "\n"))
         }
     }
 
@@ -579,7 +463,6 @@ public final class ComprehensiveTests: TestImplementation {
             testErrorHandling(),
             testReadImageWithManifest(),
             testInvalidFileHandling(),
-            testFileOperationsWithDataDir(),
             testStreamFileOptions(),
             testStreamFromData(),
             testStreamFromFile(),
@@ -591,8 +474,7 @@ public final class ComprehensiveTests: TestImplementation {
             testReaderWithTestImage(),
             testSigningAlgorithms(),
             testErrorEnumCases(),
-            testEndToEndSigning(),
-            testReadIngredient()
+            testEndToEndSigning()
         ]
     }
 }

--- a/TestShared/Sources/ConvenienceTests.swift
+++ b/TestShared/Sources/ConvenienceTests.swift
@@ -11,7 +11,7 @@
 import C2PA
 import Foundation
 
-// Tests for C2PA convenience methods (readFile, readIngredient, signFile)
+// Tests for C2PA convenience methods (readFile, signFile)
 public final class ConvenienceTests: TestImplementation {
 
     public init() {}
@@ -74,41 +74,6 @@ public final class ConvenienceTests: TestImplementation {
         }
     }
 
-    public func testReadFileWithDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("readFile with DataDir", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("data")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-            testSteps.append("Created data directory: \(dataDir.path)")
-
-            let imageURL = tempDir.appendingPathComponent("test.jpg")
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote image file")
-
-            let manifestJSON = try C2PA.readFile(at: imageURL, dataDir: dataDir)
-            testSteps.append("Read manifest with dataDir parameter")
-            testSteps.append("Manifest length: \(manifestJSON.count) characters")
-
-            return .success(
-                "readFile with DataDir",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("Error: \(error)")
-            return .failure(
-                "readFile with DataDir",
-                testSteps.joined(separator: "\n"))
-        }
-    }
-
     public func testReadFileWithoutManifest() -> TestResult {
         var testSteps: [String] = []
 
@@ -163,130 +128,6 @@ public final class ConvenienceTests: TestImplementation {
             return .success(
                 "readFile Non-existent File",
                 testSteps.joined(separator: "\n"))
-        }
-    }
-
-    // MARK: - C2PA.readIngredient Tests
-
-    public func testReadIngredientWithManifest() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("readIngredient with Manifest", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("ingredient_data")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-
-            let imageURL = tempDir.appendingPathComponent("ingredient.jpg")
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote ingredient image")
-
-            let ingredientJSON = try C2PA.readIngredient(at: imageURL, dataDir: dataDir)
-            testSteps.append("Read ingredient successfully")
-            testSteps.append("Ingredient JSON length: \(ingredientJSON.count) characters")
-
-            guard !ingredientJSON.isEmpty else {
-                return .failure("readIngredient with Manifest", "Ingredient JSON is empty")
-            }
-
-            return .success(
-                "readIngredient with Manifest",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("Error: \(error)")
-            return .failure(
-                "readIngredient with Manifest",
-                testSteps.joined(separator: "\n"))
-        }
-    }
-
-    public func testReadIngredientWithoutManifest() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadPexelsTestImage() else {
-            return .failure("readIngredient without Manifest", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("ingredient_data_nomnfst")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-
-            let imageURL = tempDir.appendingPathComponent("no_manifest_ingredient.jpg")
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote ingredient image without manifest")
-
-            // readIngredient should still work for files without manifests
-            // (it extracts ingredient info, which is different from manifest)
-            let ingredientJSON = try C2PA.readIngredient(at: imageURL, dataDir: dataDir)
-            testSteps.append("Read ingredient info for file without manifest")
-            testSteps.append("Ingredient JSON length: \(ingredientJSON.count) characters")
-
-            return .success(
-                "readIngredient without Manifest",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            // Files without manifest may or may not work with readIngredient
-            // The behavior depends on the C2PA library implementation
-            // This is a valid test path - just verify no crash occurred
-            testSteps.append("Error reading ingredient from file without manifest: \(error)")
-            testSteps.append("This behavior is acceptable - verifying no crash")
-            return .success(
-                "readIngredient without Manifest",
-                testSteps.joined(separator: "\n"))
-        }
-    }
-
-    public func testReadIngredientWithoutDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadAdobeTestImage() else {
-            return .failure("readIngredient without DataDir", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        defer { cleanupTempDirectory(tempDir) }
-
-        let imageURL = tempDir.appendingPathComponent("ingredient_no_datadir.jpg")
-
-        do {
-            try imageData.write(to: imageURL)
-            testSteps.append("Wrote ingredient image")
-
-            // Calling without dataDir - should throw an error since dataDir is required
-            _ = try C2PA.readIngredient(at: imageURL, dataDir: nil)
-
-            // If we get here without error, that's unexpected but not a test failure
-            // The API behavior may vary
-            testSteps.append("readIngredient succeeded without dataDir (unexpected)")
-            return .success(
-                "readIngredient without DataDir",
-                testSteps.joined(separator: "\n"))
-
-        } catch let error as C2PAError {
-            // Expected: error because dataDir is required
-            testSteps.append("Caught expected C2PAError: \(error)")
-            if case .api(let message) = error {
-                testSteps.append("Error message: \(message)")
-            }
-            return .success(
-                "readIngredient without DataDir (correctly throws error)",
-                testSteps.joined(separator: "\n"))
-
-        } catch {
-            testSteps.append("Caught non-C2PA error: \(error)")
-            return .failure(
-                "readIngredient without DataDir",
-                "Expected C2PAError but got: \(error)")
         }
     }
 
@@ -358,68 +199,6 @@ public final class ConvenienceTests: TestImplementation {
         }
     }
 
-    public func testSignFileWithDataDir() -> TestResult {
-        var testSteps: [String] = []
-
-        guard let imageData = TestUtilities.loadPexelsTestImage() else {
-            return .failure("signFile with DataDir", "Failed to load test image")
-        }
-
-        let tempDir = createTempDirectory()
-        let dataDir = tempDir.appendingPathComponent("sign_data")
-        defer { cleanupTempDirectory(tempDir) }
-
-        do {
-            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
-
-            let sourceURL = tempDir.appendingPathComponent("source_datadir.jpg")
-            let destURL = tempDir.appendingPathComponent("signed_datadir.jpg")
-
-            try imageData.write(to: sourceURL)
-            testSteps.append("Wrote source image")
-
-            let signerInfo = SignerInfo(
-                algorithm: .es256,
-                certificatePEM: TestUtilities.testCertsPEM,
-                privateKeyPEM: TestUtilities.testPrivateKeyPEM,
-                tsa: nil
-            )
-
-            let manifestJSON = TestUtilities.createTestManifestJSON(claimGenerator: "signFile_datadir_test/1.0")
-
-            try C2PA.signFile(
-                source: sourceURL,
-                destination: destURL,
-                manifestJSON: manifestJSON,
-                signerInfo: signerInfo,
-                dataDir: dataDir
-            )
-            testSteps.append("signFile with dataDir completed successfully")
-
-            guard FileManager.default.fileExists(atPath: destURL.path) else {
-                return .failure("signFile with DataDir", "Signed file was not created")
-            }
-            testSteps.append("Signed file created successfully")
-
-            return .success(
-                "signFile with DataDir",
-                testSteps.joined(separator: "\n"))
-
-        } catch let error as C2PAError {
-            // The convenience API with dataDir may have different behavior
-            // Test verifies the API is callable; actual signing may fail due to test certificate limitations
-            testSteps.append("C2PAError with dataDir parameter: \(error)")
-            return .success(
-                "signFile with DataDir",
-                "[WARN] Convenience API with dataDir threw C2PAError (may be expected): " + testSteps.joined(separator: "\n"))
-        } catch {
-            testSteps.append("Environment error: \(error)")
-            return .success(
-                "signFile with DataDir",
-                "[WARN] Environment issue: " + testSteps.joined(separator: "\n"))
-        }
-    }
-
     public func testSignFileWithInvalidManifest() -> TestResult {
         var testSteps: [String] = []
 
@@ -481,18 +260,27 @@ public final class ConvenienceTests: TestImplementation {
             "No invalid manifests were rejected: " + testSteps.joined(separator: ", "))
     }
 
+    public func testReadFileUnknownExtension() -> TestResult {
+        let tempDir = FileManager.default.temporaryDirectory
+        let weird = tempDir.appendingPathComponent("c2pa_unknown_\(UUID().uuidString).zzz")
+        defer { try? FileManager.default.removeItem(at: weird) }
+        do {
+            try Data([0x00, 0x01]).write(to: weird)
+            _ = try C2PA.readFile(at: weird)
+            return .failure("readFile Unknown Extension", "Expected an error for unknown extension")
+        } catch {
+            return .success("readFile Unknown Extension", "[PASS] readFile throws on unknown extension")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         var results: [TestResult] = []
 
         results.append(testReadFileWithManifest())
-        results.append(testReadFileWithDataDir())
         results.append(testReadFileWithoutManifest())
         results.append(testReadFileNonExistent())
-        results.append(testReadIngredientWithManifest())
-        results.append(testReadIngredientWithoutManifest())
-        results.append(testReadIngredientWithoutDataDir())
+        results.append(testReadFileUnknownExtension())
         results.append(testSignFile())
-        results.append(testSignFileWithDataDir())
         results.append(testSignFileWithInvalidManifest())
 
         return results

--- a/TestShared/Sources/ReaderTests.swift
+++ b/TestShared/Sources/ReaderTests.swift
@@ -530,6 +530,41 @@ public final class ReaderTests: TestImplementation {
         }
     }
 
+    public func testReaderSupportedMimeTypes() -> TestResult {
+        let types = Reader.supportedMimeTypes
+        guard !types.isEmpty else {
+            return .failure("Reader Supported MIME Types", "Expected a non-empty list")
+        }
+        guard types.contains("image/jpeg") else {
+            return .failure("Reader Supported MIME Types", "Expected image/jpeg in \(types.prefix(10))")
+        }
+        return .success("Reader Supported MIME Types", "[PASS] \(types.count) types incl. image/jpeg")
+    }
+
+    public func testReaderFromContext() -> TestResult {
+        do {
+            guard let imageData = TestUtilities.loadAdobeTestImage() else {
+                return .failure("Reader From Context", "Could not load test image")
+            }
+            let settings = try C2PASettings(json: "{\"version\": 1}")
+            let context = try C2PAContext(settings: settings)
+            let reader = try Reader(
+                context: context,
+                format: "image/jpeg",
+                stream: try Stream(data: imageData)
+            )
+            let json = try reader.json()
+            guard !json.isEmpty else {
+                return .failure("Reader From Context", "json was empty")
+            }
+            return .success("Reader From Context", "[PASS] read \(json.count) chars via context-configured Reader")
+        } catch let error as C2PAError {
+            return .success("Reader From Context", "[WARN] context Reader callable (error: \(error))")
+        } catch {
+            return .failure("Reader From Context", "Error: \(error)")
+        }
+    }
+
     public func runAllTests() async -> [TestResult] {
         return [
             testReaderResourceErrorHandling(),
@@ -543,7 +578,9 @@ public final class ReaderTests: TestImplementation {
             testReaderRemoteURL(),
             testReaderIsEmbedded(),
             testReaderDetailedJSON(),
-            testReaderDetailedJSONComparison()
+            testReaderDetailedJSONComparison(),
+            testReaderSupportedMimeTypes(),
+            testReaderFromContext()
         ]
     }
 }


### PR DESCRIPTION
## Changes in this pull request

Migrates away from the deprecated FFI read/sign functions, instead routing through context and streams. Expands Builder/Reader capabilities with base-path resource resolution, supported-MIME-type introspection, ingredient-archive import/export, and Reader context configuration.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All applicable changes have been documented
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment